### PR TITLE
Allowed the setting of AccountEmail variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ providers {
 variable "pingdom_user" {}
 variable "pingdom_password" {}
 variable "pingdom_api_key" {}
+variable "pingdom_account_email" {} # Optional: only required for multi-user accounts
 
 provider "pingdom" {
     user = "${var.pingdom_user}"
     password = "${var.pingdom_password}"
     api_key = "${var.pingdom_api_key}"
+    account_email = "${var.pingdom_account_email}" # Optional: only required for multi-user accounts
 }
 
 resource "pingdom_check" "example" {

--- a/pingdom/config.go
+++ b/pingdom/config.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Config struct {
-	User     string `mapstructure:"user"`
-	Password string `mapstructure:"password"`
-	APIKey   string `mapstructure:"api_key"`
+	User         string `mapstructure:"user"`
+	Password     string `mapstructure:"password"`
+	APIKey       string `mapstructure:"api_key"`
+	AccountEmail string `mapstructure:"account_email"`
 }
 
 // Client() returns a new client for accessing pingdom.
@@ -26,8 +27,15 @@ func (c *Config) Client() (*pingdom.Client, error) {
 	if v := os.Getenv("PINGDOM_API_KEY"); v != "" {
 		c.APIKey = v
 	}
+	if v := os.Getenv("PINGDOM_ACCOUNT_EMAIL"); v != "" {
+		c.AccountEmail = v
+	}
 
 	client := pingdom.NewClient(c.User, c.Password, c.APIKey)
+	if c.AccountEmail != "" {
+		client = pingdom.NewMultiUserClient(c.User, c.Password, c.APIKey, c.AccountEmail)
+	}
+
 
 	log.Printf("[INFO] Pingdom Client configured for user: %s", c.User)
 

--- a/pingdom/provider.go
+++ b/pingdom/provider.go
@@ -25,6 +25,10 @@ func Provider() terraform.ResourceProvider {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"account_email": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"pingdom_check": resourcePingdomCheck(),

--- a/pingdom/provider.go
+++ b/pingdom/provider.go
@@ -27,6 +27,7 @@ func Provider() terraform.ResourceProvider {
 			},
 			"account_email": &schema.Schema{
 				Type:     schema.TypeString,
+				Default: "",
 				Optional: true,
 			},
 		},

--- a/pingdom/provider_test.go
+++ b/pingdom/provider_test.go
@@ -30,6 +30,7 @@ func TestProviderConfigure(t *testing.T) {
 	var expectedUser string
 	var expectedPassword string
 	var expectedKey string
+	var expectedAccountEmail string
 
 	if v := os.Getenv("PINGDOM_USER"); v != "" {
 		expectedUser = v
@@ -49,10 +50,17 @@ func TestProviderConfigure(t *testing.T) {
 		expectedKey = "foo"
 	}
 
+	if v := os.Getenv("PINGDOM_ACCOUNT_EMAIL"); v != "" {
+		expectedAccountEmail = v
+	} else {
+		expectedAccountEmail = "foo"
+	}
+
 	raw := map[string]interface{}{
 		"user":     expectedUser,
 		"password": expectedPassword,
 		"api_key":  expectedKey,
+		"account_email":  expectedAccountEmail,
 	}
 
 	rawConfig, err := config.NewRawConfig(raw)


### PR DESCRIPTION
# Why

Pingdom has single-user and multi-user accounts. When using a multi-user account you need to supply the account owner email in the `Account-Email` header when calling the API. We received this error message when using this library:
```
Error applying plan:

2 error(s) occurred:

* pingdom_check.ping_example: 403 Forbidden: Not permitted for account type.
* pingdom_check.example: 403 Forbidden: Not permitted for account type.

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

We want to be able to authenticate in multi-user Pingdom accounts. For this we need to pass an `AccountEmail` variable, which is the email address of the account holder.

# What 

Added logic to `config.go` to check if the Account Email variable is set and override the client object using the new constructor if appropriate. 

# How to review

To be reviewed in conjuction with the [pull request on go-pingdom library](https://github.com/russellcardullo/go-pingdom/pull/2)