### PR TITLE
Feature/allow define HTTP check specific attributes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ resource "pingdom_check" "example" {
 
 ### Pingdom Check ###
 
-The following attributes can be set:
+#### Common Attibutes ####
+
+The following common attributes for all check types can be set:
 
 **name** - (Required) The name of the check
 
@@ -132,6 +134,28 @@ The following attributes can be set:
 **notifywhenbackup** - Notify when backup.
 
 **uselegacynotifications** - Use legacy (UP/DOWN) notifications if true.
+
+#### HTTP specific attibutes ####
+
+For the HTTP checks, you can set these attributes:
+
+**url** - Target path on server.
+
+**encryption** - Enable encryption in the HTTP check (aka HTTPS).
+
+**port** - Target port for HTTP checks.
+
+**username** - Username for target HTTP authentication.
+
+**password** - Password for target HTTP authentication.
+
+**shouldcontain** - Target site should contain this string.
+
+**shouldnotcontain** - Target site should NOT contain this string. Not allowed defined together with `shouldcontain`.
+
+**postdata** - Data that should be posted to the web page, for example submission data for a sign-up or login form. The data needs to be formatted in the same way as a web browser would send it to the web server.
+
+**requestheaders** - Custom HTTP headers. It should be a hash with pairs, like `{ "header_name" = "header_content" }`
 
 The following attributes are exported:
 

--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/russellcardullo/go-pingdom/pingdom"
@@ -81,6 +82,7 @@ func resourcePingdomCheck() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 
 			"notifyagainevery": &schema.Schema{
@@ -93,6 +95,7 @@ func resourcePingdomCheck() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 
 			"uselegacynotifications": &schema.Schema{
@@ -117,6 +120,7 @@ func resourcePingdomCheck() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 
 			"username": &schema.Schema{
@@ -369,6 +373,34 @@ func resourcePingdomCheckRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("hostname", ck.Hostname)
 	d.Set("name", ck.Name)
 	d.Set("resolution", ck.Resolution)
+	d.Set("sendtoandroid", ck.SendToAndroid)
+	d.Set("sendtoemail", ck.SendToEmail)
+	d.Set("sendtoiphone", ck.SendToIPhone)
+	d.Set("sendtosms", ck.SendToSms)
+	d.Set("sendtotwitter", ck.SendToTwitter)
+	d.Set("sendnotificationwhendown", ck.SendNotificationWhenDown)
+	d.Set("notifyagainevery", ck.NotifyAgainEvery)
+	d.Set("notifywhenbackup", ck.NotifyWhenBackup)
+	d.Set("hostname", ck.Hostname)
+
+	if ck.Type.HTTP == nil {
+		ck.Type.HTTP = &pingdom.CheckResponseHTTPDetails{}
+	}
+	d.Set("url", ck.Type.HTTP.Url)
+	d.Set("encryption", ck.Type.HTTP.Encryption)
+	d.Set("port", ck.Type.HTTP.Port)
+	d.Set("username", ck.Type.HTTP.Username)
+	d.Set("password", ck.Type.HTTP.Password)
+	d.Set("shouldcontain", ck.Type.HTTP.ShouldContain)
+	d.Set("shouldnotcontain", ck.Type.HTTP.ShouldNotContain)
+	d.Set("postdata", ck.Type.HTTP.PostData)
+
+	if v, ok := ck.Type.HTTP.RequestHeaders["User-Agent"]; ok {
+		if strings.HasPrefix(v, "Pingdom.com_bot_version_") {
+			delete(ck.Type.HTTP.RequestHeaders, "User-Agent")
+		}
+	}
+	d.Set("requestheaders", ck.Type.HTTP.RequestHeaders)
 
 	return nil
 }

--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -346,6 +346,21 @@ func resourcePingdomCheckRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving id for resource: %s", err)
 	}
+	cl, err := client.Checks.List()
+	if err != nil {
+		return fmt.Errorf("Error retrieving list of checks: %s", err)
+	}
+	exists := false
+	for _, ckid := range cl {
+		if ckid.ID == id {
+			exists = true
+			break
+		}
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
 	ck, err := client.Checks.Read(id)
 	if err != nil {
 		return fmt.Errorf("Error retrieving check: %s", err)

--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -100,6 +100,60 @@ func resourcePingdomCheck() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 			},
+
+			"encryption": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"username": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"password": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"shouldcontain": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"shouldnotcontain": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"postdata": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+
+			"requestheaders": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: false,
+			},
 		},
 	}
 }
@@ -118,6 +172,15 @@ type commonCheckParams struct {
 	NotifyAgainEvery         int
 	NotifyWhenBackup         bool
 	UseLegacyNotifications   bool
+	Url                      string
+	Encryption               bool
+	Port                     int
+	Username                 string
+	Password                 string
+	ShouldContain            string
+	ShouldNotContain         string
+	PostData                 string
+	RequestHeaders           map[string]string
 }
 
 func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
@@ -168,6 +231,45 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 		checkParams.UseLegacyNotifications = v.(bool)
 	}
 
+	if v, ok := d.GetOk("url"); ok {
+		checkParams.Url = v.(string)
+	}
+
+	if v, ok := d.GetOk("encryption"); ok {
+		checkParams.Encryption = v.(bool)
+	}
+
+	if v, ok := d.GetOk("port"); ok {
+		checkParams.Port = v.(int)
+	}
+
+	if v, ok := d.GetOk("username"); ok {
+		checkParams.Username = v.(string)
+	}
+
+	if v, ok := d.GetOk("password"); ok {
+		checkParams.Password = v.(string)
+	}
+
+	if v, ok := d.GetOk("shouldcontain"); ok {
+		checkParams.ShouldContain = v.(string)
+	}
+
+	if v, ok := d.GetOk("shouldnotcontain"); ok {
+		checkParams.ShouldNotContain = v.(string)
+	}
+
+	if v, ok := d.GetOk("postdata"); ok {
+		checkParams.PostData = v.(string)
+	}
+
+	if m, ok := d.GetOk("requestheaders"); ok {
+		checkParams.RequestHeaders = make(map[string]string)
+		for k, v := range m.(map[string]interface{}) {
+			checkParams.RequestHeaders[k] = v.(string)
+		}
+	}
+
 	checkType := d.Get("type")
 	switch checkType {
 	case "http":
@@ -185,6 +287,15 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 			NotifyAgainEvery:         checkParams.NotifyAgainEvery,
 			NotifyWhenBackup:         checkParams.NotifyWhenBackup,
 			UseLegacyNotifications:   checkParams.UseLegacyNotifications,
+			Encryption:               checkParams.Encryption,
+			Url:                      checkParams.Url,
+			Port:                     checkParams.Port,
+			Username:                 checkParams.Username,
+			Password:                 checkParams.Password,
+			ShouldContain:            checkParams.ShouldContain,
+			ShouldNotContain:         checkParams.ShouldNotContain,
+			PostData:                 checkParams.PostData,
+			RequestHeaders:           checkParams.RequestHeaders,
 		}, nil
 	case "ping":
 		return &pingdom.PingCheck{


### PR DESCRIPTION
Pingdom API [supports define several specific attributes for HTTP checks](https://www.pingdom.com/resources/api#MethodGet+Detailed+Check+Information). 

Once this PR is merged https://github.com/russellcardullo/go-pingdom/pull/3, we can use the new features in go-pingdom to define them in terraform.

In this PR we add:
 * Support to define detailed attributes for HTTP check during creation.
 * Support to read and update the attributes if they changed.
 * Detect if the resource has been deleted so it can be recreated if needed.

See commit comments for more details.