### PR TITLE
Add contact IDs to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ resource "pingdom_check" "example" {
     resolution = 5
 }
 
+resource "pingdom_check" "example_with_alert" {
+    type = "http"
+    name = "my http check"
+    host = "example.com"
+    resolution = 5
+    uselegacynotifications = true
+    sendtoemail = true
+    sendnotificationwhendown = 2
+    contactids = [
+      12345678
+    ]
+}
+
 resource "pingdom_check" "ping_example" {
     type = "ping"
     name = "my ping check"
@@ -134,6 +147,8 @@ The following common attributes for all check types can be set:
 **notifywhenbackup** - Notify when backup.
 
 **uselegacynotifications** - Use legacy (UP/DOWN) notifications if true.
+
+**contactids** - List of integer contact IDs that will receive the alerts. The ID can be extracted from the contact page URL on the pingdom website.
 
 #### HTTP specific attibutes ####
 


### PR DESCRIPTION
## What

We want to be able to set up Pingdom checks that alert us via email by providing a list of contact IDs for email recipients. 

This change will allow you to set the `contactids` field in a `pingdom_check` resource. The field takes a list of contact IDs as integers. The contact IDs are then provided when [creating a Pingdom check](https://www.pingdom.com/resources/api#MethodCreate+New+Check).

This relies on [the PR on go-pingdom](https://github.com/russellcardullo/go-pingdom/pull/4) to be merged first because it allows using contacts in checks.

The go-pingdom PR allows the complete management of notification contacts and this will be implemented as a resource in the terraform provider at a later date.

## How to review

* Change the checks to add alerts using the sample Terraform config below:

```
variable "pingdom_user" {}
variable "pingdom_password" {}
variable "pingdom_api_key" {}
variable "pingdom_account_email" {}
variable "contact_ids" {}

provider "pingdom" {
    user = "${var.pingdom_user}"
    password = "${var.pingdom_password}"
    api_key = "${var.pingdom_api_key}"
    account_email = "${var.pingdom_account_email}"
}

resource "pingdom_check" "paas_http_healthcheck" {
    type = "http"
    name = "Google"
    host = "www.google.com"
    encryption = true
    resolution = 1
    uselegacynotifications = true
    sendtoemail = true
    sendnotificationwhendown = 6
    contactids = ["${split(",", var.contact_ids)}"]
}
```
* Run Terraform with the right variables:

```
terraform apply \
	-var "contact_ids=${PINGDOM_CONTACT_IDS}" \
	-var "pingdom_user=${PINGDOM_USER}" \
	-var "pingdom_password=${PINGDOM_PASSWORD}" \
	-var "pingdom_api_key=${PINGDOM_API_KEY}" \
	-var "pingdom_account_email=${PINGDOM_ACCOUNT_EMAIL}"
```
* The contact IDs can be retrieved in the URL of the contact pages on the pingdom website. They must be passed as a comma-delimited string, ex: "11111111,22222222".
* Log into the Pingdom UI. It should have email alerts set up with the contacts as recipients.
