### PR TITLE
Added support for tagging checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ For the HTTP checks, you can set these attributes:
 
 **requestheaders** - Custom HTTP headers. It should be a hash with pairs, like `{ "header_name" = "header_content" }`
 
+**tags** - List of tags the check should contain. Should be in the format "tagA,tagB"
+
 The following attributes are exported:
 
 **id** The ID of the Pingdom check

--- a/pingdom/config.go
+++ b/pingdom/config.go
@@ -36,7 +36,6 @@ func (c *Config) Client() (*pingdom.Client, error) {
 		client = pingdom.NewMultiUserClient(c.User, c.Password, c.APIKey, c.AccountEmail)
 	}
 
-
 	log.Printf("[INFO] Pingdom Client configured for user: %s", c.User)
 
 	return client, nil

--- a/pingdom/provider_test.go
+++ b/pingdom/provider_test.go
@@ -57,10 +57,10 @@ func TestProviderConfigure(t *testing.T) {
 	}
 
 	raw := map[string]interface{}{
-		"user":     expectedUser,
-		"password": expectedPassword,
-		"api_key":  expectedKey,
-		"account_email":  expectedAccountEmail,
+		"user":          expectedUser,
+		"password":      expectedPassword,
+		"api_key":       expectedKey,
+		"account_email": expectedAccountEmail,
 	}
 
 	rawConfig, err := config.NewRawConfig(raw)

--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -164,6 +164,11 @@ func resourcePingdomCheck() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 			},
+			"tags": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
 		},
 	}
 }
@@ -192,6 +197,7 @@ type commonCheckParams struct {
 	ShouldNotContain         string
 	PostData                 string
 	RequestHeaders           map[string]string
+	Tags                     string
 }
 
 func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
@@ -289,6 +295,9 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 			checkParams.RequestHeaders[k] = v.(string)
 		}
 	}
+	if v, ok := d.GetOk("tags"); ok {
+		checkParams.Tags = v.(string)
+	}
 
 	checkType := d.Get("type")
 	switch checkType {
@@ -317,6 +326,7 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 			ShouldNotContain:         checkParams.ShouldNotContain,
 			PostData:                 checkParams.PostData,
 			RequestHeaders:           checkParams.RequestHeaders,
+			Tags:                     checkParams.Tags,
 		}, nil
 	case "ping":
 		return &pingdom.PingCheck{


### PR DESCRIPTION
Hi,

for our DataDog Integration with Pingdom we rely on tagged checks. This commit adds support for optionally tagging a check.

This PR should only be merged after the PR to go-pingdom has been merged:
https://github.com/russellcardullo/go-pingdom/pull/6

Cheers,

Johannes