### PR TITLE
Add support for pause setting

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/jayhding/terraform-provider-pingdom/pingdom"
+	"github.com/russellcardullo/terraform-provider-pingdom/pingdom"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/russellcardullo/terraform-provider-pingdom/pingdom"
+	"github.com/jayhding/terraform-provider-pingdom/pingdom"
 )
 
 func main() {

--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -383,11 +383,14 @@ func resourcePingdomCheckRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("host", ck.Hostname)
 	d.Set("name", ck.Name)
-	d.Set("paused", ck.Paused)
 	d.Set("resolution", ck.Resolution)
 	d.Set("sendnotificationwhendown", ck.SendNotificationWhenDown)
 	d.Set("notifyagainevery", ck.NotifyAgainEvery)
 	d.Set("notifywhenbackup", ck.NotifyWhenBackup)
+
+  if ck.Status == "paused" {
+		d.Set("paused", true)
+	}
 
 	integids := schema.NewSet(
 		func(integrationId interface{}) int { return integrationId.(int) },

--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -39,6 +39,12 @@ func resourcePingdomCheck() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"paused": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+			},
+
 			"resolution": {
 				Type:     schema.TypeInt,
 				Required: true,
@@ -189,6 +195,10 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 	}
 	if v, ok := d.GetOk("host"); ok {
 		checkParams.Hostname = v.(string)
+	}
+
+	if v, ok := d.GetOk("paused"); ok {
+		checkParams.Paused = v.(bool)
 	}
 
 	if v, ok := d.GetOk("resolution"); ok {
@@ -373,6 +383,7 @@ func resourcePingdomCheckRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("host", ck.Hostname)
 	d.Set("name", ck.Name)
+	d.Set("paused", ck.Paused)
 	d.Set("resolution", ck.Resolution)
 	d.Set("sendnotificationwhendown", ck.SendNotificationWhenDown)
 	d.Set("notifyagainevery", ck.NotifyAgainEvery)


### PR DESCRIPTION
Pingdom api already provides `paused` status setting and `commonCheckParams` in this provider also includes `Paused` parameter. However, paused status is not part of check create and read methods.

This pull request adds support for creating checks with paused or unpaused (as default) status and updating checks according to latest terraform configuration as well.