### PR TITLE
vendor: fix teams response

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -409,11 +409,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c9b57ef29534bbadd34f4bd30e005d6de0dbd6cba3823d15b6ecf8f3f1ef85b8"
+  digest = "1:b31877b4429ba22ce944d75f76588e54d474df5cfba9e86d891ad0b8951a36e4"
   name = "github.com/russellcardullo/go-pingdom"
   packages = ["pingdom"]
   pruneopts = "UT"
-  revision = "c133ad715b052af44e474516fe837e5fc51761f8"
+  revision = "c0cd353f706f3e31914a293d5a1fe7b07481af66"
 
 [[projects]]
   digest = "1:db345c377984d0907323c09a9b17f11d995a59649fd38f909727df358b5f9020"

--- a/vendor/github.com/russellcardullo/go-pingdom/pingdom/api_responses.go
+++ b/vendor/github.com/russellcardullo/go-pingdom/pingdom/api_responses.go
@@ -19,25 +19,36 @@ type PingdomError struct {
 
 // CheckResponse represents the json response for a check from the Pingdom API
 type CheckResponse struct {
-	ID                       int                `json:"id"`
-	Name                     string             `json:"name"`
-	Resolution               int                `json:"resolution,omitempty"`
-	SendNotificationWhenDown int                `json:"sendnotificationwhendown,omitempty"`
-	NotifyAgainEvery         int                `json:"notifyagainevery,omitempty"`
-	NotifyWhenBackup         bool               `json:"notifywhenbackup,omitempty"`
-	Created                  int64              `json:"created,omitempty"`
-	Hostname                 string             `json:"hostname,omitempty"`
-	Status                   string             `json:"status,omitempty"`
-	LastErrorTime            int64              `json:"lasterrortime,omitempty"`
-	LastTestTime             int64              `json:"lasttesttime,omitempty"`
-	LastResponseTime         int64              `json:"lastresponsetime,omitempty"`
-	Paused                   bool               `json:"paused,omitempty"`
-	IntegrationIds           []int              `json:"integrationids,omitempty"`
-	Type                     CheckResponseType  `json:"type,omitempty"`
-	Tags                     []CheckResponseTag `json:"tags,omitempty"`
-	UserIds                  []int              `json:"userids,omitempty"`
-	TeamIds                  []int              `json:"teamids,omitempty"`
-	ResponseTimeThreshold    int                `json:"responsetime_threshold,omitempty"`
+	ID                       int                 `json:"id"`
+	Name                     string              `json:"name"`
+	Resolution               int                 `json:"resolution,omitempty"`
+	SendNotificationWhenDown int                 `json:"sendnotificationwhendown,omitempty"`
+	NotifyAgainEvery         int                 `json:"notifyagainevery,omitempty"`
+	NotifyWhenBackup         bool                `json:"notifywhenbackup,omitempty"`
+	Created                  int64               `json:"created,omitempty"`
+	Hostname                 string              `json:"hostname,omitempty"`
+	Status                   string              `json:"status,omitempty"`
+	LastErrorTime            int64               `json:"lasterrortime,omitempty"`
+	LastTestTime             int64               `json:"lasttesttime,omitempty"`
+	LastResponseTime         int64               `json:"lastresponsetime,omitempty"`
+	Paused                   bool                `json:"paused,omitempty"`
+	IntegrationIds           []int               `json:"integrationids,omitempty"`
+	Type                     CheckResponseType   `json:"type,omitempty"`
+	Tags                     []CheckResponseTag  `json:"tags,omitempty"`
+	UserIds                  []int               `json:"userids,omitempty"`
+	Teams                    []CheckTeamResponse `json:"teams,omitempty"`
+	ResponseTimeThreshold    int                 `json:"responsetime_threshold,omitempty"`
+
+	// Legacy; this is not returned by the API, we backfill the value from the
+	// Teams field.
+	TeamIds []int
+}
+
+// CheckTeamResponse is a Team returned inside of a Check instance. (We can't
+// use TeamResponse because the ID returned here is an int, not a string)
+type CheckTeamResponse struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
 }
 
 type CheckResponseType struct {
@@ -70,7 +81,7 @@ type MaintenanceCheckResponse struct {
 	Tms    []int `json:"tms"`
 }
 
-// ProbeResponse represents the json response for probes from the PIngdom API
+// ProbeResponse represents the json response for probes from the Pingdom API
 type ProbeResponse struct {
 	ID         int    `json:"id"`
 	Country    string `json:"country"`
@@ -84,21 +95,21 @@ type ProbeResponse struct {
 	Region     string `json:"region"`
 }
 
-// TeamResponse represents the json response for teams from the PIngdom API
+// TeamResponse represents the json response for teams from the Pingdom API
 type TeamResponse struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Users []TeamUserResponse
 }
 
-// TeamUserResponse represents the json response for users in teams from the PIngdom API
+// TeamUserResponse represents the json response for users in teams from the Pingdom API
 type TeamUserResponse struct {
 	ID    string `json:"id"`
 	Email string `json:"email"`
 	Name  string `json:"name"`
 }
 
-// TeamDeleteResponse represents the json response for delete team from the PIngdom API
+// TeamDeleteResponse represents the json response for delete team from the Pingdom API
 type TeamDeleteResponse struct {
 	Success bool `json:"success"`
 }
@@ -115,30 +126,30 @@ type SummaryPerformanceResponse struct {
 
 type SummaryPerformanceMap struct {
 	Hours []SummaryPerformanceSummary `json:"hours,omitempty"`
-	Days []SummaryPerformanceSummary `json:"days,omitempty"`
+	Days  []SummaryPerformanceSummary `json:"days,omitempty"`
 	Weeks []SummaryPerformanceSummary `json:"weeks,omitempty"`
 }
 
 type SummaryPerformanceSummary struct {
 	AvgResponse int `json:"avgresponse"`
-	Downtime int `json:"downtime"`
-	StartTime int `json:"starttime"`
+	Downtime    int `json:"downtime"`
+	StartTime   int `json:"starttime"`
 	Unmonitored int `json:"unmonitored"`
-	Uptime int `json:"uptime"`
+	Uptime      int `json:"uptime"`
 }
 
 type UserSmsResponse struct {
-	Id int `json:"id"`
-	Severity string `json:"severity"`
+	Id          int    `json:"id"`
+	Severity    string `json:"severity"`
 	CountryCode string `json:"country_code"`
-	Number string `json:"number"`
-	Provider string `json:"provider"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
 }
 
 type UserEmailResponse struct {
-	Id int `json:"id"`
+	Id       int    `json:"id"`
 	Severity string `json:"severity"`
-	Address string `json:"address"`
+	Address  string `json:"address"`
 }
 
 type CreateUserContactResponse struct {
@@ -147,11 +158,11 @@ type CreateUserContactResponse struct {
 
 // MaintenanceWindow represents a Pingdom Maintenance Window.
 type UsersResponse struct {
-	Id    		   int  `json:"id"`
-	Paused         string  `json:"paused,omitempty"`
-	Username       string `json:"name,omitempty"`
-	Sms			   []UserSmsResponse `json:"sms,omitempty"`
-	Email 		   []UserEmailResponse `json:"email,omitempty"`
+	Id       int                 `json:"id"`
+	Paused   string              `json:"paused,omitempty"`
+	Username string              `json:"name,omitempty"`
+	Sms      []UserSmsResponse   `json:"sms,omitempty"`
+	Email    []UserEmailResponse `json:"email,omitempty"`
 }
 
 func (c *CheckResponseType) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/russellcardullo/go-pingdom/pingdom/check.go
+++ b/vendor/github.com/russellcardullo/go-pingdom/pingdom/check.go
@@ -77,7 +77,7 @@ func (cs *CheckService) Create(check Check) (*CheckResponse, error) {
 // This returns type CheckResponse rather than Check since the
 // pingdom API does not return a complete representation of a check.
 func (cs *CheckService) Read(id int) (*CheckResponse, error) {
-	req, err := cs.client.NewRequest("GET", "/checks/"+strconv.Itoa(id), nil)
+	req, err := cs.client.NewRequest("GET", "/checks/"+strconv.Itoa(id)+"?include_teams=true", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -86,6 +86,10 @@ func (cs *CheckService) Read(id int) (*CheckResponse, error) {
 	_, err = cs.client.Do(req, m)
 	if err != nil {
 		return nil, err
+	}
+	m.Check.TeamIds = make([]int, len(m.Check.Teams))
+	for i := range m.Check.Teams {
+		m.Check.TeamIds[i] = m.Check.Teams[i].ID
 	}
 
 	return m.Check, err
@@ -127,7 +131,7 @@ func (cs *CheckService) Delete(id int) (*PingdomResponse, error) {
 	return m, err
 }
 
-func (cs *CheckService) SummaryPerformance(request SummaryPerformanceRequest) (*SummaryPerformanceResponse, error){
+func (cs *CheckService) SummaryPerformance(request SummaryPerformanceRequest) (*SummaryPerformanceResponse, error) {
 	if err := request.Valid(); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/russellcardullo/go-pingdom/pingdom/pingdom.go
+++ b/vendor/github.com/russellcardullo/go-pingdom/pingdom/pingdom.go
@@ -27,7 +27,7 @@ type Client struct {
 	Probes       *ProbeService
 	Teams        *TeamService
 	PublicReport *PublicReportService
-	Users		     *UserService
+	Users        *UserService
 }
 
 // NewClient returns a Pingdom client with a default base URL and HTTP client

--- a/vendor/github.com/russellcardullo/go-pingdom/pingdom/user.go
+++ b/vendor/github.com/russellcardullo/go-pingdom/pingdom/user.go
@@ -1,10 +1,10 @@
 package pingdom
 
 import (
-	"io/ioutil"
 	"encoding/json"
-	"strconv"
 	"fmt"
+	"io/ioutil"
+	"strconv"
 )
 
 type UserService struct {
@@ -90,7 +90,7 @@ func (cs *UserService) CreateContact(userId int, contact Contact) (*CreateUserCo
 		return nil, err
 	}
 
-	req, err := cs.client.NewRequest("POST", "/users/"+ strconv.Itoa(userId), contact.PostContactParams())
+	req, err := cs.client.NewRequest("POST", "/users/"+strconv.Itoa(userId), contact.PostContactParams())
 	if err != nil {
 		return nil, err
 	}
@@ -121,6 +121,7 @@ func (cs *UserService) Update(id int, user UserApi) (*PingdomResponse, error) {
 	}
 	return m, err
 }
+
 // Update a contact by id, will change an email to sms or sms to email
 // if you provide an id for the other
 func (cs *UserService) UpdateContact(userId int, contactId int, contact Contact) (*PingdomResponse, error) {
@@ -128,7 +129,7 @@ func (cs *UserService) UpdateContact(userId int, contactId int, contact Contact)
 		return nil, err
 	}
 
-	req, err := cs.client.NewRequest("PUT",  "/users/"+strconv.Itoa(userId)+"/"+strconv.Itoa(contactId), contact.PutContactParams())
+	req, err := cs.client.NewRequest("PUT", "/users/"+strconv.Itoa(userId)+"/"+strconv.Itoa(contactId), contact.PutContactParams())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/russellcardullo/go-pingdom/pingdom/user_types.go
+++ b/vendor/github.com/russellcardullo/go-pingdom/pingdom/user_types.go
@@ -7,35 +7,35 @@ import (
 // User email represents the sms contact object in a user in
 // GET /users
 type UserSms struct {
-	Severity string `json:"severity"`
+	Severity    string `json:"severity"`
 	CountryCode string `json:"country_code"`
-	Number string `json:"number"`
-	Provider string `json:"provider"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
 }
 
 // User email represents the email contact object in a user in
 // GET /users
 type UserEmail struct {
 	Severity string `json:"severity"`
-	Address string `json:"address"`
+	Address  string `json:"address"`
 }
 
 // Contact represents a Pingdom contact target
 type Contact struct {
-	Severity string `json:"severitylevel"`
+	Severity    string `json:"severitylevel"`
 	CountryCode string `json:"countrycode"`
-	Number string `json:"number"`
-	Provider string `json:"provider"`
-	Email string `json:"email"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
+	Email       string `json:"email"`
 }
 
 // User represents a Pingdom User or Contact.
 type User struct {
-	Paused         string  `json:"paused,omitempty"`
-	Username       string `json:"name,omitempty"`
-	Primary		   string `json:"primary,omitempty"`
-	Sms			   []UserSmsResponse `json:"sms,omitempty"`
-	Email 		   []UserEmailResponse `json:"email,omitempty"`
+	Paused   string              `json:"paused,omitempty"`
+	Username string              `json:"name,omitempty"`
+	Primary  string              `json:"primary,omitempty"`
+	Sms      []UserSmsResponse   `json:"sms,omitempty"`
+	Email    []UserEmailResponse `json:"email,omitempty"`
 }
 
 func (u *User) ValidUser() error {
@@ -51,13 +51,13 @@ func (u *User) ValidUser() error {
 func (c *Contact) ValidContact() error {
 	if c.Email == "" && c.Number == "" {
 		return fmt.Errorf("you must provide either an Email or a Phone Number to create a contact target")
-}
+	}
 
 	if c.Number != "" && c.CountryCode == "" {
 		return fmt.Errorf("you must provide a Country Code if providing a phone number")
 	}
 
-	if c.Provider != "" && ( c.Number == "" || c.CountryCode == "" ){
+	if c.Provider != "" && (c.Number == "" || c.CountryCode == "") {
 		return fmt.Errorf("you must provide CountryCode and Number if Provider is provided")
 	}
 
@@ -101,7 +101,7 @@ func (c *Contact) PostContactParams() map[string]string {
 
 func (u *User) PutParams() map[string]string {
 	m := map[string]string{
-		"name" : u.Username,
+		"name": u.Username,
 	}
 
 	if u.Primary != "" {
@@ -119,4 +119,3 @@ func (u *User) PutParams() map[string]string {
 func (c *Contact) PutContactParams() map[string]string {
 	return c.PostContactParams()
 }
-


### PR DESCRIPTION
Previously every "terraform plan" would report a diff if you tried to
specify a teamid, because retrieving the existing checks failed to
grab the TeamId field properly. Incorporate a client library change
that retrieves the team ids appropriately, so plan correctly reports
"no changes" for resources that include a team id.

Fixes russellcardullo/terraform-provider-pingdom#26.