### PR TITLE
Add travis for tests and releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: go
+go:
+  - '1.11'
+  - '1.12'
+  - master
+matrix:
+  allow_failures:
+    - go: master
+install:
+  - export TF_LOG=INFO
+  - go get
+script:
+  - go build -v
+  - ls
+  - TF_ACC=1 go test -v -cover ./...
+before_deploy:
+  - export GO111MODULE=on
+  - go get github.com/mitchellh/gox
+  - export TARGET_OS="freebsd darwin linux windows"
+  - export TARGET_ARCH="386 amd64"
+  # rename to match terraform provider conventions:
+  #  https://www.terraform.io/docs/configuration/providers.html#third-party-plugins
+  - export FILE_NAME="terraform-provider-pingdom_${TRAVIS_TAG}_{{.OS}}_{{.Arch}}"
+  - gox -os "$TARGET_OS" -arch "$TARGET_ARCH" -output="$FILE_NAME"
+  - CGO_ENABLED=0 gox -os "$TARGET_OS" -arch "$TARGET_ARCH" -output="${FILE_NAME}_static"
+deploy:
+  provider: releases
+  api_key:
+    secure: fill-me-in
+  file: terraform-provider-pingdom*
+  skip_cleanup: true
+  file_glob: true
+  on:
+    tags: true
+    branch: master
+    go: '1.12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: fill-me-in
+    secure: "TV2bTe8iDwSAcHE4sN8xLZs9AUAFXKwKK3NzLHOrl6aJCbdozm6zP5Lr2/H6+2GjaUNMbZBchuCvMDjksV+oM185LPk7wYQPWy4ZStBienKxFVM+NMFueCID48fR/l0Z08QzfepszKH6IEt9RJlhJTvUeDgiRxSv6qHOb+8zFfA="
   file: terraform-provider-pingdom*
   skip_cleanup: true
   file_glob: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,4 @@ deploy:
     tags: true
     branch: master
     go: '1.12'
+    repo: russellcardullo/terraform-provider-pingdom


### PR DESCRIPTION
For https://github.com/russellcardullo/terraform-provider-pingdom/issues/39.

In order to add the encrypted key: 

Create a personal access token on this page: https://github.com/settings/tokens/new.
* Check the "repo" permission and the permissions underneath it (repo:status, repo_deployment, public_repo)
* Save the key to a `github.key`

Get the public key for this repo:
```
curl -H 'Content-Type: application/json' https://api.travis-ci.org/repos/phillbaker/terraform-provider-pingdom/key | jq -r '.key' > travis.key
```

```
cat github.key | openssl rsautl -encrypt -inkey travis.key -pubin | base64 
```

References:
https://gist.github.com/openscript/082bd53b28505337510d9e69386b5fc5
https://github.com/travis-ci/travis-ci/issues/2982#issuecomment-358873469

Passing here:
https://travis-ci.org/phillbaker/terraform-provider-pingdom/jobs/582471109
