### PR TITLE
Read probefilters

### DIFF
--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -504,6 +504,11 @@ func resourcePingdomCheckRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("teamids", teamids)
 
+	if probefilters := ck.ProbeFilters; len(probefilters) > 0 {
+		// normalise: "region: NA" -> "region:NA"
+		d.Set("probefilters", strings.Replace(probefilters[0], ": ", ":", 1))
+	}
+
 	if ck.Type.HTTP != nil {
 		d.Set("type", "http")
 		d.Set("responsetime_threshold", ck.ResponseTimeThreshold)


### PR DESCRIPTION
I think this was an inadvertent omission from this provider plugin.  The
necessary support for this attribute already exists in all the right
places (including the README); we simply forgot to tell Terraform to pay
attention to the attr on reads.

This patch is not strictly correct.  Pingdom allow users to specify
anywhere from zero to many probefilters on a check.  This patch will
only pay attention to the first.

The `probe_filters` attribute is not type-symmetric on reads and writes.

reads:  https://www.pingdom.com/api/2.1/#MethodGet+Check+List
writes: https://www.pingdom.com/api/2.1/#MethodCreate+New+Check

On reads, the API returns an array.  On writes, the API expects a
comma-separated string.  I expect element ordering is _not_ maintained
across write-read cycles.  It would be possible for us to support any
number of probefilters in Terraform, however we would be obliged to
migrate this type from a string to a set-of-strings, which would be a
breaking change for existing plugin users.

Conveniently, the README for this plugin states the following:

    probefilters - Region from which the check should originate. One of
    NA, EU, APAC, or LATAM. Should be in the format "region:NA"

There is no mention of probefilter cardinality.  We can meet that easy
promise with this simple patch. :)