### PR TITLE
CI Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 examples/*.tfstate*
 examples/*.tfstate.backup
 examples/*.tfvars
+
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ go:
   - '1.11'
   - '1.12'
   - master
+env:
+  - GO111MODULE=on
 matrix:
   allow_failures:
     - go: master
@@ -14,7 +16,6 @@ script:
   - ls
   - TF_ACC=1 go test -v -cover ./...
 before_deploy:
-  - export GO111MODULE=on
   - go get github.com/mitchellh/gox
   - export TARGET_OS="freebsd darwin linux windows"
   - export TARGET_ARCH="386 amd64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ install:
   - export TF_LOG=INFO
   - go get
 script:
-  - go build -v
-  - ls
-  - TF_ACC=1 go test -v -cover ./...
+  - make test build
 before_deploy:
   - go get github.com/mitchellh/gox
   - export TARGET_OS="freebsd darwin linux windows"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - '1.11'
   - '1.12'
+  - '1.13'
   - master
 env:
   - GO111MODULE=on
@@ -32,5 +32,5 @@ deploy:
   on:
     tags: true
     branch: master
-    go: '1.12'
+    go: '1.13'
     repo: russellcardullo/terraform-provider-pingdom

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,25 @@
+GOOS := $(shell go env GOOS)
+GOARCH := $(shell go env GOARCH)
+TAG := $(shell git describe --abbrev=0 --tags)
+TF_PLUGIN_PATH := $(HOME)/.terraform.d/plugins/$(GOOS)_$(GOARCH)
+PLUGIN_NAME := terraform-provider-pingdom
+
+default: build
+
+build:
+	go build -o build/$(PLUGIN_NAME)_$(TAG)
+
+install: build
+	install -d $(TF_PLUGIN_PATH) && \
+		install build/$(PLUGIN_NAME)_$(TAG) $(TF_PLUGIN_PATH)
+
+lint:
+	golangci-lint run
+
+test:
+	go test -v -cover ./...
+
+clean:
+	rm -rf build/
+
+.PHONY: build install lint test clean

--- a/README.md
+++ b/README.md
@@ -6,29 +6,35 @@ This currently only supports working with basic HTTP and ping checks.
 
 ## Build and install ##
 
-### Dependencies ###
+### Using released versions ###
 
-You should have a working Go environment setup.  If not check out the Go [getting started](http://golang.org/doc/install) guide.
+Prebuild releases for most platforms are available [here](https://github.com/russellcardullo/terraform-provider-pingdom/releases).
+Download the release corresponding to your particular platform and place in `$HOME/.terraform.d/plugins/[os]_[arch]`.  For instance
+on Linux AMD64 the path would be `$HOME/.terraform.d/plugins/linux_amd64`.
+
+After copying the plugin run `terraform init` in your projects that use this provider.
+
+### Dependencies for building from source ###
+
+If you need to build from source, you should have a working Go environment setup.  If not check out the Go [getting started](http://golang.org/doc/install) guide.
 
 This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) for dependency management.  To fetch all dependencies run `go get` inside this repository.
 
 ### Build ###
 
 ```
-go get github.com/russellcardullo/terraform-provider-pingdom
+make build
 ```
 
-The binary will then be available at `~/go/bin/terraform-provider-pingdom`, unless you've set `$GOPATH`, in which case you'll find it at `$GOPATH/bin`
+The binary will then be available at `_build/terraform-provider-pingdom_VERSION`.
 
 ### Install ###
 
-You will need to install the binary as a [terraform third party plugin](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins).  Terraform will then pick up the binary from the local filesystem when you run `terraform init`.
-
 ```
-ln -s ~/go/bin/terraform-provider-pingdom ~/.terraform.d/plugins/$(uname | tr '[:upper:]' '[:lower:]')_amd64/terraform-provider-pingdom_v$(date +%Y.%m.%d)
+make install
 ```
 
-Updates can now be applied by re-running `go get github.com/russellcardullo/terraform-provider-pingdom`.
+This will place the binary under `$HOME/.terraform.d/plugins/OS_ARCH/terraform-provider-pingdom_VERSION`.  After installing you will need to run `terraform init` in any project using the plugin.
 
 ## Usage ##
 


### PR DESCRIPTION
Makes the following improvements to the CI setup:

* Set `GO111MODULE=on` for CI to use the versions defined in `go.mod` in CI
* Adds a Makefile and call those functions for building and testing
* Adds an install target into the Makefile to make it easier in local development flows
* Remove Go 1.11 support as it's no longer supported in the latest Terraform.
* Adds Go 1.13 as a matrix item in CI