### PR TITLE
docs: clarify webhook interactions with sendnotificationswhendown

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,17 +193,19 @@ The following common attributes for all check types can be set:
 
   * **type** - (Required) The check type.  Allowed values: (http, ping).
 
-  * **sendnotificationwhendown** - The number of consecutive failed checks required to trigger an alert. Values of 0 are ignored.
+  * **sendnotificationwhendown** - The number of consecutive failed checks required to trigger an alert. Values of 0 are ignored. See note about interaction with `integrationids` below.
 
   * **notifyagainevery** - Notify again after n results.  A value of 0 means no additional notifications will be sent.
 
   * **notifywhenbackup** - Notify when backup.
 
-  * **integrationids** - List of integer integration IDs (defined by webhook URL) that will be triggered by the alerts. The ID can be extracted from the integrations page URL on the pingdom website.
+  * **integrationids** - List of integer integration IDs (defined by webhook URL) that will be triggered by the alerts. The ID can be extracted from the integrations page URL on the pingdom website. See note about interaction with `sendnotificationwhendown` below.
 
   * **userids** - List of integer user IDs that will be notified when the check is down.
 
   * **teamids** - List of integer team IDs that will be notified when the check is down.
+
+Note that when using `integrationids`, the `sendnotificationswhendown` value will be ignored when sending webhook notifications.  You may need to contact Pingdom support for more details.  See #52.
 
 #### HTTP specific attibutes ####
 


### PR DESCRIPTION
Adds a note to the README to clarify how webhooks interact with the
sendnotificationswhendown value.

Fixes #52.