### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The following common attributes for all check types can be set:
 
   * **notifyagainevery** - Notify again after n results.  A value of 0 means no additional notifications will be sent.
 
-  * **notifywhenbackup** - Notify when backup.
+  * **notifywhenbackup** - Notify when back up.
 
   * **integrationids** - List of integer integration IDs (defined by webhook URL) that will be triggered by the alerts. The ID can be extracted from the integrations page URL on the pingdom website. See note about interaction with `sendnotificationwhendown` below.
 


### PR DESCRIPTION
s/backup/back up

since the meanings differ, and this has to do with the service / endpoint "coming back up", and not backups.

thanks for making this provider!