### PR TITLE
Fix false error when creating users with email notifications

### DIFF
--- a/pingdom/resource_pingdom_contact.go
+++ b/pingdom/resource_pingdom_contact.go
@@ -110,6 +110,12 @@ func getNotificationMethods(d *schema.ResourceData) (pingdom.NotificationTargets
 			Address:  input["address"].(string),
 			Severity: input["severity"].(string),
 		}
+		if email.Severity == "HIGH" {
+			hasHighSeverity = true
+		}
+		if email.Severity == "LOW" {
+			hasLowSeverity = true
+		}
 		base.Email = append(base.Email, email)
 	}
 


### PR DESCRIPTION
The provider  checks if HIGH and LOW severity of a contact are set. Both must have at least one notification method configured. currently only `sms_notification`s are considered in this verification process. This PR sets the high and low severity flags correctly in case of email notifications.