### PR TITLE
Fix pingdom_contact data source returning wrong ID

### DIFF
--- a/pingdom/data_source_pingdom_contact.go
+++ b/pingdom/data_source_pingdom_contact.go
@@ -96,6 +96,7 @@ func dataSourcePingdomContactRead(d *schema.ResourceData, meta interface{}) erro
 		if contact.Name == name {
 			log.Printf("Contact: %v", contact)
 			found = &contact
+			break
 		}
 	}
 	if found == nil {


### PR DESCRIPTION
Fixes #85 
Adding a "break" to the for loop that iterates through the contacts list so that the "contact" variable doesn't get overwritten and therefore the "found" variable ends up pointing to the correct value.